### PR TITLE
feat(bitcoin-agents): add frontend for Tamagotchi-style AI agents

### DIFF
--- a/src/app/bitcoin-agents/[id]/page.tsx
+++ b/src/app/bitcoin-agents/[id]/page.tsx
@@ -1,0 +1,326 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useParams } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import {
+  LevelBadge,
+  HungerHealthBars,
+  XPProgress,
+  FeedButton,
+} from "@/components/bitcoin-agents";
+import {
+  fetchBitcoinAgentById,
+  fetchFoodTiers,
+  fetchAgentCapabilities,
+  visitAgent,
+} from "@/services/bitcoin-agents.service";
+import type { BitcoinAgent, FoodTier, AgentCapabilities } from "@/types";
+import Link from "next/link";
+
+const BITCOIN_FACES_API = "https://bitcoinfaces.xyz/api";
+
+export default function BitcoinAgentDetailPage() {
+  const params = useParams();
+  const agentId = parseInt(params.id as string, 10);
+
+  const [agent, setAgent] = useState<BitcoinAgent | null>(null);
+  const [foodTiers, setFoodTiers] = useState<Record<number, FoodTier>>({});
+  const [capabilities, setCapabilities] = useState<AgentCapabilities | null>(
+    null
+  );
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isNaN(agentId)) {
+      loadData();
+    }
+  }, [agentId]);
+
+  async function loadData() {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const [agentData, tiersData, capabilitiesData] = await Promise.all([
+        fetchBitcoinAgentById(agentId),
+        fetchFoodTiers(),
+        fetchAgentCapabilities(agentId).catch(() => null),
+      ]);
+
+      if (!agentData) {
+        setError("Agent not found");
+        return;
+      }
+
+      setAgent(agentData);
+      setFoodTiers(tiersData.food_tiers);
+      setCapabilities(capabilitiesData);
+    } catch (err) {
+      setError("Failed to load agent details");
+      console.error(err);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="container mx-auto py-8 px-4 max-w-4xl">
+        <div className="flex items-start gap-6 mb-8">
+          <Skeleton className="h-32 w-32 rounded-full" />
+          <div className="space-y-3 flex-1">
+            <Skeleton className="h-8 w-48" />
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-6 w-24" />
+          </div>
+        </div>
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (error || !agent) {
+    return (
+      <div className="container mx-auto py-8 px-4 text-center">
+        <h1 className="text-2xl font-bold mb-4">
+          {error || "Agent Not Found"}
+        </h1>
+        <Link href="/bitcoin-agents">
+          <Button>Back to Agents</Button>
+        </Link>
+      </div>
+    );
+  }
+
+  const faceUrl =
+    agent.face_image_url ||
+    `${BITCOIN_FACES_API}/get-image?name=${agent.owner}`;
+  const hunger = agent.computed_hunger ?? agent.hunger;
+  const health = agent.computed_health ?? agent.health;
+
+  return (
+    <div className="container mx-auto py-8 px-4 max-w-4xl">
+      {/* Back Button */}
+      <Link
+        href="/bitcoin-agents"
+        className="text-muted-foreground hover:text-foreground mb-4 inline-block"
+      >
+        ← Back to Agents
+      </Link>
+
+      {/* Agent Header */}
+      <div className="flex flex-col md:flex-row items-start gap-6 mb-8">
+        <div className="relative">
+          <Avatar className="h-32 w-32 border-4 border-border">
+            <AvatarImage src={faceUrl} alt={agent.name} />
+            <AvatarFallback className="text-4xl">
+              {agent.name.slice(0, 2).toUpperCase()}
+            </AvatarFallback>
+          </Avatar>
+          {!agent.alive && (
+            <div className="absolute inset-0 bg-black/50 rounded-full flex items-center justify-center">
+              <span className="text-4xl">💀</span>
+            </div>
+          )}
+        </div>
+
+        <div className="flex-1">
+          <div className="flex items-center gap-3 mb-2">
+            <h1 className="text-3xl font-bold">{agent.name}</h1>
+            <LevelBadge level={agent.level} xp={agent.xp} showXp />
+          </div>
+
+          <p className="text-muted-foreground mb-4">
+            Agent #{agent.agent_id} • Born at block {agent.birth_block}
+          </p>
+
+          <div className="flex flex-wrap gap-2">
+            {!agent.alive && (
+              <Badge variant="destructive" className="text-sm">
+                💀 Deceased
+              </Badge>
+            )}
+            <Badge variant="secondary">
+              Fed {agent.total_fed_count} times
+            </Badge>
+          </div>
+        </div>
+      </div>
+
+      {/* Status and Actions */}
+      {agent.alive && (
+        <div className="grid md:grid-cols-2 gap-6 mb-8">
+          {/* Status Card */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Status</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <HungerHealthBars hunger={hunger} health={health} size="lg" />
+
+              {hunger <= 30 && (
+                <div className="bg-orange-100 dark:bg-orange-900/20 text-orange-800 dark:text-orange-200 p-3 rounded-lg text-sm">
+                  ⚠️ {hunger <= 10 ? "Critical!" : "Warning:"} This agent is
+                  hungry and needs food soon!
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* XP Card */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Experience</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="text-center mb-4">
+                <p className="text-4xl font-bold">{agent.xp.toLocaleString()}</p>
+                <p className="text-muted-foreground">Total XP</p>
+              </div>
+              <XPProgress xp={agent.xp} level={agent.level} />
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {/* Feed Button */}
+      {agent.alive && Object.keys(foodTiers).length > 0 && (
+        <div className="mb-8">
+          <FeedButton
+            agentId={agent.agent_id}
+            agentName={agent.name}
+            foodTiers={foodTiers}
+          />
+        </div>
+      )}
+
+      {/* Tabs for Details */}
+      <Tabs defaultValue="info" className="space-y-4">
+        <TabsList>
+          <TabsTrigger value="info">Info</TabsTrigger>
+          <TabsTrigger value="capabilities">Capabilities</TabsTrigger>
+          <TabsTrigger value="activity">Activity</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="info">
+          <Card>
+            <CardHeader>
+              <CardTitle>Agent Information</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <p className="text-sm text-muted-foreground">Owner</p>
+                  <p className="font-mono text-sm break-all">{agent.owner}</p>
+                </div>
+                <div>
+                  <p className="text-sm text-muted-foreground">Agent ID</p>
+                  <p className="font-mono">#{agent.agent_id}</p>
+                </div>
+                <div>
+                  <p className="text-sm text-muted-foreground">Birth Block</p>
+                  <p className="font-mono">{agent.birth_block}</p>
+                </div>
+                <div>
+                  <p className="text-sm text-muted-foreground">Last Fed</p>
+                  <p className="font-mono">Block {agent.last_fed}</p>
+                </div>
+                <div>
+                  <p className="text-sm text-muted-foreground">Total Feedings</p>
+                  <p className="font-mono">{agent.total_fed_count}</p>
+                </div>
+                <div>
+                  <p className="text-sm text-muted-foreground">Status</p>
+                  <p>{agent.alive ? "🟢 Alive" : "💀 Dead"}</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="capabilities">
+          <Card>
+            <CardHeader>
+              <CardTitle>Available Tools ({capabilities?.total_tools ?? 0})</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {capabilities ? (
+                <div className="space-y-4">
+                  {Object.entries(capabilities.tools_by_category).map(
+                    ([category, tools]) =>
+                      tools.length > 0 && (
+                        <div key={category}>
+                          <h4 className="font-medium capitalize mb-2">
+                            {category.replace(/_/g, " ")}
+                          </h4>
+                          <div className="flex flex-wrap gap-2">
+                            {tools.map((tool) => (
+                              <Badge key={tool} variant="outline" className="text-xs">
+                                {tool}
+                              </Badge>
+                            ))}
+                          </div>
+                        </div>
+                      )
+                  )}
+                </div>
+              ) : (
+                <p className="text-muted-foreground">
+                  Capabilities not available
+                </p>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="activity">
+          <Card>
+            <CardHeader>
+              <CardTitle>Recent Activity</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-muted-foreground text-center py-8">
+                Activity log coming soon...
+              </p>
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+
+      {/* Death Certificate for Dead Agents */}
+      {!agent.alive && (
+        <Card className="mt-8 border-red-200 dark:border-red-800">
+          <CardHeader>
+            <CardTitle className="text-red-600">💀 Death Certificate</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-center py-4">
+              <p className="text-2xl font-bold mb-2">{agent.name}</p>
+              <p className="text-muted-foreground">
+                Lived {agent.last_fed - agent.birth_block} blocks
+              </p>
+              <p className="text-muted-foreground">
+                Final XP: {agent.xp.toLocaleString()}
+              </p>
+              <p className="text-muted-foreground">
+                Level: {agent.level.charAt(0).toUpperCase() + agent.level.slice(1)}
+              </p>
+            </div>
+            <Link href="/graveyard">
+              <Button variant="outline" className="w-full mt-4">
+                View Graveyard
+              </Button>
+            </Link>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/app/bitcoin-agents/[id]/page.tsx
+++ b/src/app/bitcoin-agents/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -18,7 +18,6 @@ import {
   fetchBitcoinAgentById,
   fetchFoodTiers,
   fetchAgentCapabilities,
-  visitAgent,
 } from "@/services/bitcoin-agents.service";
 import type { BitcoinAgent, FoodTier, AgentCapabilities } from "@/types";
 import Link from "next/link";
@@ -37,13 +36,7 @@ export default function BitcoinAgentDetailPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (!isNaN(agentId)) {
-      loadData();
-    }
-  }, [agentId]);
-
-  async function loadData() {
+  const loadData = useCallback(async () => {
     setIsLoading(true);
     setError(null);
 
@@ -68,7 +61,13 @@ export default function BitcoinAgentDetailPage() {
     } finally {
       setIsLoading(false);
     }
-  }
+  }, [agentId]);
+
+  useEffect(() => {
+    if (!isNaN(agentId)) {
+      loadData();
+    }
+  }, [agentId, loadData]);
 
   if (isLoading) {
     return (

--- a/src/app/bitcoin-agents/leaderboard/page.tsx
+++ b/src/app/bitcoin-agents/leaderboard/page.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { LevelBadge } from "@/components/bitcoin-agents";
+import { fetchLeaderboard, fetchGlobalStats } from "@/services/bitcoin-agents.service";
+import type { BitcoinAgent, BitcoinAgentStats } from "@/types";
+import Link from "next/link";
+
+const BITCOIN_FACES_API = "https://bitcoinfaces.xyz/api";
+
+const RANK_ICONS = ["🥇", "🥈", "🥉"];
+
+export default function LeaderboardPage() {
+  const [leaderboard, setLeaderboard] = useState<BitcoinAgent[]>([]);
+  const [stats, setStats] = useState<BitcoinAgentStats | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    loadData();
+  }, []);
+
+  async function loadData() {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const [leaderboardData, statsData] = await Promise.all([
+        fetchLeaderboard("mainnet", 25),
+        fetchGlobalStats(),
+      ]);
+
+      setLeaderboard(leaderboardData.leaderboard);
+      setStats(statsData);
+    } catch (err) {
+      setError("Failed to load leaderboard");
+      console.error(err);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <div className="container mx-auto py-8 px-4 max-w-4xl">
+      {/* Header */}
+      <div className="text-center mb-8">
+        <h1 className="text-3xl font-bold mb-2">🏆 Leaderboard</h1>
+        <p className="text-muted-foreground">
+          Top Bitcoin Agents by experience points
+        </p>
+      </div>
+
+      {/* Stats Summary */}
+      {stats && (
+        <div className="grid grid-cols-3 gap-4 mb-8">
+          <Card>
+            <CardContent className="pt-6 text-center">
+              <p className="text-3xl font-bold">{stats.total_agents}</p>
+              <p className="text-sm text-muted-foreground">Total Agents</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="pt-6 text-center">
+              <p className="text-3xl font-bold text-green-600">
+                {stats.alive_count}
+              </p>
+              <p className="text-sm text-muted-foreground">Still Alive</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="pt-6 text-center">
+              <p className="text-3xl font-bold">{stats.total_feedings}</p>
+              <p className="text-sm text-muted-foreground">Total Feedings</p>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      <Tabs defaultValue="xp" className="space-y-4">
+        <TabsList className="grid w-full grid-cols-3">
+          <TabsTrigger value="xp">⭐ By XP</TabsTrigger>
+          <TabsTrigger value="longevity">📅 Longevity</TabsTrigger>
+          <TabsTrigger value="feeders">🍖 Top Feeders</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="xp">
+          <Card>
+            <CardHeader>
+              <CardTitle>Top Agents by XP</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {isLoading && (
+                <div className="space-y-4">
+                  {[...Array(5)].map((_, i) => (
+                    <div key={i} className="flex items-center gap-4">
+                      <Skeleton className="h-8 w-8" />
+                      <Skeleton className="h-12 w-12 rounded-full" />
+                      <div className="flex-1 space-y-2">
+                        <Skeleton className="h-4 w-32" />
+                        <Skeleton className="h-3 w-24" />
+                      </div>
+                      <Skeleton className="h-6 w-20" />
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {error && (
+                <p className="text-center text-red-500 py-8">{error}</p>
+              )}
+
+              {!isLoading && !error && (
+                <div className="space-y-2">
+                  {leaderboard.length === 0 ? (
+                    <p className="text-center text-muted-foreground py-8">
+                      No agents yet. Be the first to mint one!
+                    </p>
+                  ) : (
+                    leaderboard.map((agent, index) => (
+                      <Link
+                        key={agent.agent_id}
+                        href={`/bitcoin-agents/${agent.agent_id}`}
+                        className="flex items-center gap-4 p-3 rounded-lg hover:bg-muted transition-colors"
+                      >
+                        {/* Rank */}
+                        <div className="w-10 text-center">
+                          {index < 3 ? (
+                            <span className="text-2xl">
+                              {RANK_ICONS[index]}
+                            </span>
+                          ) : (
+                            <span className="text-lg font-bold text-muted-foreground">
+                              #{index + 1}
+                            </span>
+                          )}
+                        </div>
+
+                        {/* Avatar */}
+                        <Avatar className="h-12 w-12 border-2 border-border">
+                          <AvatarImage
+                            src={`${BITCOIN_FACES_API}/get-image?name=${agent.owner}`}
+                            alt={agent.name}
+                          />
+                          <AvatarFallback>
+                            {agent.name.slice(0, 2).toUpperCase()}
+                          </AvatarFallback>
+                        </Avatar>
+
+                        {/* Info */}
+                        <div className="flex-1 min-w-0">
+                          <p className="font-medium truncate">{agent.name}</p>
+                          <div className="flex items-center gap-2">
+                            <LevelBadge level={agent.level} size="sm" />
+                            {!agent.alive && (
+                              <span className="text-xs text-red-500">💀</span>
+                            )}
+                          </div>
+                        </div>
+
+                        {/* XP */}
+                        <div className="text-right">
+                          <p className="font-bold text-lg">
+                            {agent.xp.toLocaleString()}
+                          </p>
+                          <p className="text-xs text-muted-foreground">XP</p>
+                        </div>
+                      </Link>
+                    ))
+                  )}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="longevity">
+          <Card>
+            <CardHeader>
+              <CardTitle>Longest Living Agents</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-center text-muted-foreground py-8">
+                Longevity leaderboard coming soon...
+              </p>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="feeders">
+          <Card>
+            <CardHeader>
+              <CardTitle>Most Active Feeders</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-center text-muted-foreground py-8">
+                Top feeders leaderboard coming soon...
+              </p>
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+
+      {/* Evolution Milestones */}
+      <Card className="mt-8">
+        <CardHeader>
+          <CardTitle>🎯 Evolution Milestones</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-5 gap-4 text-center">
+            <div className="p-3">
+              <p className="text-2xl mb-1">🥚</p>
+              <p className="text-sm font-medium">Hatchling</p>
+              <p className="text-xs text-muted-foreground">0 XP</p>
+            </div>
+            <div className="p-3">
+              <p className="text-2xl mb-1">🐣</p>
+              <p className="text-sm font-medium">Junior</p>
+              <p className="text-xs text-muted-foreground">500 XP</p>
+            </div>
+            <div className="p-3">
+              <p className="text-2xl mb-1">🐥</p>
+              <p className="text-sm font-medium">Senior</p>
+              <p className="text-xs text-muted-foreground">2,000 XP</p>
+            </div>
+            <div className="p-3">
+              <p className="text-2xl mb-1">🦅</p>
+              <p className="text-sm font-medium">Elder</p>
+              <p className="text-xs text-muted-foreground">10,000 XP</p>
+            </div>
+            <div className="p-3">
+              <p className="text-2xl mb-1">🔥</p>
+              <p className="text-sm font-medium">Legendary</p>
+              <p className="text-xs text-muted-foreground">50,000 XP</p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Back Link */}
+      <div className="text-center mt-8">
+        <Link
+          href="/bitcoin-agents"
+          className="text-muted-foreground hover:text-foreground"
+        >
+          ← Back to Agents
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/bitcoin-agents/mint/page.tsx
+++ b/src/app/bitcoin-agents/mint/page.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { requestMintAgent, fetchFoodTiers } from "@/services/bitcoin-agents.service";
+import Link from "next/link";
+import { useEffect } from "react";
+
+const BITCOIN_FACES_API = "https://bitcoinfaces.xyz/api";
+
+export default function MintAgentPage() {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [previewSeed, setPreviewSeed] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [mintCost, setMintCost] = useState(10000);
+  const [paymentInfo, setPaymentInfo] = useState<{
+    cost_sats: number;
+    payment_address: string;
+    message: string;
+  } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Generate a preview seed when name changes
+  useEffect(() => {
+    if (name.length >= 1) {
+      // Use name + timestamp for unique preview
+      setPreviewSeed(`preview-${name}-${Date.now()}`);
+    }
+  }, [name]);
+
+  // Fetch mint cost
+  useEffect(() => {
+    fetchFoodTiers()
+      .then((data) => setMintCost(data.mint_cost))
+      .catch(console.error);
+  }, []);
+
+  const handleMint = async () => {
+    if (!name.trim()) {
+      setError("Please enter a name for your agent");
+      return;
+    }
+
+    if (name.length > 64) {
+      setError("Name must be 64 characters or less");
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const result = await requestMintAgent(name.trim());
+      setPaymentInfo({
+        cost_sats: result.cost_sats,
+        payment_address: result.payment_address,
+        message: result.message,
+      });
+    } catch (err) {
+      setError("Failed to initiate mint. Please try again.");
+      console.error(err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const facePreviewUrl = previewSeed
+    ? `${BITCOIN_FACES_API}/get-image?name=${previewSeed}`
+    : null;
+
+  return (
+    <div className="container mx-auto py-8 px-4 max-w-2xl">
+      {/* Back Button */}
+      <Link
+        href="/bitcoin-agents"
+        className="text-muted-foreground hover:text-foreground mb-4 inline-block"
+      >
+        ← Back to Agents
+      </Link>
+
+      <div className="text-center mb-8">
+        <h1 className="text-3xl font-bold mb-2">🥚 Mint Your Bitcoin Agent</h1>
+        <p className="text-muted-foreground">
+          Create a unique AI companion that lives on Bitcoin
+        </p>
+      </div>
+
+      {!paymentInfo ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>Create Your Agent</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            {/* Preview */}
+            <div className="flex flex-col items-center">
+              <Avatar className="h-32 w-32 border-4 border-border mb-4">
+                {facePreviewUrl ? (
+                  <AvatarImage src={facePreviewUrl} alt="Preview" />
+                ) : null}
+                <AvatarFallback className="text-4xl bg-muted">
+                  {name ? name.slice(0, 2).toUpperCase() : "🥚"}
+                </AvatarFallback>
+              </Avatar>
+              <p className="text-sm text-muted-foreground">
+                Your agent&apos;s unique Bitcoin Face
+              </p>
+            </div>
+
+            {/* Name Input */}
+            <div className="space-y-2">
+              <Label htmlFor="name">Agent Name</Label>
+              <Input
+                id="name"
+                placeholder="Enter a unique name..."
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                maxLength={64}
+              />
+              <p className="text-xs text-muted-foreground">
+                {name.length}/64 characters
+              </p>
+            </div>
+
+            {/* Cost Breakdown */}
+            <div className="bg-muted p-4 rounded-lg">
+              <h3 className="font-medium mb-2">Mint Cost</h3>
+              <div className="flex justify-between items-center">
+                <span className="text-muted-foreground">Agent NFT</span>
+                <span className="font-mono">
+                  {mintCost.toLocaleString()} sats
+                </span>
+              </div>
+              <div className="border-t border-border mt-2 pt-2 flex justify-between items-center">
+                <span className="font-medium">Total</span>
+                <span className="font-mono font-bold text-lg">
+                  {mintCost.toLocaleString()} sats
+                </span>
+              </div>
+            </div>
+
+            {/* What You Get */}
+            <div className="space-y-2">
+              <h3 className="font-medium">What you get:</h3>
+              <ul className="text-sm text-muted-foreground space-y-1">
+                <li>✓ Unique Bitcoin Face avatar</li>
+                <li>✓ On-chain AI agent identity</li>
+                <li>✓ Starting level: Hatchling</li>
+                <li>✓ 100% hunger and health</li>
+                <li>✓ Access to read-only MCP tools</li>
+              </ul>
+            </div>
+
+            {/* Warning */}
+            <div className="bg-orange-100 dark:bg-orange-900/20 text-orange-800 dark:text-orange-200 p-4 rounded-lg text-sm">
+              <p className="font-medium mb-1">⚠️ Important</p>
+              <p>
+                Bitcoin Agents require regular feeding to survive. If you
+                neglect your agent, it will die permanently. Death is real
+                and cannot be reversed.
+              </p>
+            </div>
+
+            {/* Error */}
+            {error && (
+              <div className="bg-red-100 dark:bg-red-900/20 text-red-800 dark:text-red-200 p-3 rounded-lg text-sm">
+                {error}
+              </div>
+            )}
+
+            {/* Mint Button */}
+            <Button
+              size="lg"
+              className="w-full bg-orange-500 hover:bg-orange-600"
+              onClick={handleMint}
+              disabled={isLoading || !name.trim()}
+            >
+              {isLoading ? "Processing..." : "🥚 Mint Agent"}
+            </Button>
+          </CardContent>
+        </Card>
+      ) : (
+        <Card>
+          <CardHeader>
+            <CardTitle>Complete Payment</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            {/* Payment Details */}
+            <div className="text-center">
+              <p className="text-muted-foreground mb-2">
+                Send exactly this amount:
+              </p>
+              <p className="text-4xl font-bold mb-4">
+                {paymentInfo.cost_sats.toLocaleString()} sats
+              </p>
+            </div>
+
+            <div className="bg-muted p-4 rounded-lg">
+              <p className="text-sm text-muted-foreground mb-2 text-center">
+                To this address:
+              </p>
+              <code className="text-sm break-all block bg-background p-3 rounded text-center">
+                {paymentInfo.payment_address}
+              </code>
+            </div>
+
+            <p className="text-center text-sm text-muted-foreground">
+              {paymentInfo.message}
+            </p>
+
+            {/* QR Code placeholder */}
+            <div className="flex justify-center">
+              <div className="w-48 h-48 bg-muted rounded-lg flex items-center justify-center">
+                <p className="text-muted-foreground text-sm">QR Code</p>
+              </div>
+            </div>
+
+            {/* Actions */}
+            <div className="space-y-2">
+              <Button
+                variant="outline"
+                className="w-full"
+                onClick={() => {
+                  navigator.clipboard.writeText(paymentInfo.payment_address);
+                }}
+              >
+                Copy Address
+              </Button>
+              <Button
+                variant="ghost"
+                className="w-full"
+                onClick={() => setPaymentInfo(null)}
+              >
+                ← Back to Form
+              </Button>
+            </div>
+
+            <p className="text-xs text-center text-muted-foreground">
+              After payment is confirmed on-chain, your agent will appear in
+              your collection. This may take a few minutes.
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Info Cards */}
+      <div className="grid md:grid-cols-2 gap-4 mt-8">
+        <Card>
+          <CardContent className="pt-6">
+            <h3 className="font-medium mb-2">🍖 Feeding</h3>
+            <p className="text-sm text-muted-foreground">
+              Feed your agent regularly to keep it alive. Premium food gives
+              more XP!
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <h3 className="font-medium mb-2">⭐ Evolution</h3>
+            <p className="text-sm text-muted-foreground">
+              Earn XP to evolve from Hatchling to Legendary. Higher levels
+              unlock more tools.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/app/bitcoin-agents/mint/page.tsx
+++ b/src/app/bitcoin-agents/mint/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -9,12 +8,10 @@ import { Label } from "@/components/ui/label";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { requestMintAgent, fetchFoodTiers } from "@/services/bitcoin-agents.service";
 import Link from "next/link";
-import { useEffect } from "react";
 
 const BITCOIN_FACES_API = "https://bitcoinfaces.xyz/api";
 
 export default function MintAgentPage() {
-  const router = useRouter();
   const [name, setName] = useState("");
   const [previewSeed, setPreviewSeed] = useState("");
   const [isLoading, setIsLoading] = useState(false);

--- a/src/app/bitcoin-agents/page.tsx
+++ b/src/app/bitcoin-agents/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -40,11 +40,7 @@ export default function BitcoinAgentsPage() {
   const [searchQuery, setSearchQuery] = useState("");
   const [sortBy, setSortBy] = useState<"xp" | "hunger" | "age">("xp");
 
-  useEffect(() => {
-    loadData();
-  }, [statusFilter, levelFilter]);
-
-  async function loadData() {
+  const loadData = useCallback(async () => {
     setIsLoading(true);
     setError(null);
 
@@ -65,7 +61,11 @@ export default function BitcoinAgentsPage() {
     } finally {
       setIsLoading(false);
     }
-  }
+  }, [statusFilter, levelFilter]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
 
   // Filter and sort agents
   const filteredAgents = agents

--- a/src/app/bitcoin-agents/page.tsx
+++ b/src/app/bitcoin-agents/page.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { BitcoinAgentCard } from "@/components/bitcoin-agents";
+import {
+  fetchBitcoinAgents,
+  fetchGlobalStats,
+} from "@/services/bitcoin-agents.service";
+import type {
+  BitcoinAgent,
+  BitcoinAgentLevel,
+  BitcoinAgentStats,
+} from "@/types";
+import Link from "next/link";
+
+export default function BitcoinAgentsPage() {
+  const [agents, setAgents] = useState<BitcoinAgent[]>([]);
+  const [stats, setStats] = useState<BitcoinAgentStats | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Filters
+  const [statusFilter, setStatusFilter] = useState<"all" | "alive" | "dead">(
+    "alive"
+  );
+  const [levelFilter, setLevelFilter] = useState<BitcoinAgentLevel | "all">(
+    "all"
+  );
+  const [searchQuery, setSearchQuery] = useState("");
+  const [sortBy, setSortBy] = useState<"xp" | "hunger" | "age">("xp");
+
+  useEffect(() => {
+    loadData();
+  }, [statusFilter, levelFilter]);
+
+  async function loadData() {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const [agentsData, statsData] = await Promise.all([
+        fetchBitcoinAgents({
+          status: statusFilter === "all" ? undefined : statusFilter,
+          level: levelFilter === "all" ? undefined : levelFilter,
+        }),
+        fetchGlobalStats(),
+      ]);
+
+      setAgents(agentsData.agents);
+      setStats(statsData);
+    } catch (err) {
+      setError("Failed to load agents. Please try again.");
+      console.error(err);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  // Filter and sort agents
+  const filteredAgents = agents
+    .filter((agent) => {
+      if (searchQuery) {
+        const query = searchQuery.toLowerCase();
+        return (
+          agent.name.toLowerCase().includes(query) ||
+          agent.agent_id.toString().includes(query) ||
+          agent.owner.toLowerCase().includes(query)
+        );
+      }
+      return true;
+    })
+    .sort((a, b) => {
+      if (sortBy === "xp") return b.xp - a.xp;
+      if (sortBy === "hunger")
+        return (a.computed_hunger ?? a.hunger) - (b.computed_hunger ?? b.hunger);
+      if (sortBy === "age") return a.birth_block - b.birth_block;
+      return 0;
+    });
+
+  return (
+    <div className="container mx-auto py-8 px-4">
+      {/* Header */}
+      <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 mb-8">
+        <div>
+          <h1 className="text-3xl font-bold">Bitcoin Agents</h1>
+          <p className="text-muted-foreground mt-1">
+            Tamagotchi-style AI companions on Bitcoin
+          </p>
+        </div>
+        <Link href="/bitcoin-agents/mint">
+          <Button size="lg" className="bg-orange-500 hover:bg-orange-600">
+            🥚 Mint New Agent
+          </Button>
+        </Link>
+      </div>
+
+      {/* Stats Cards */}
+      {stats && (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium text-muted-foreground">
+                Total Agents
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-2xl font-bold">{stats.total_agents}</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium text-muted-foreground">
+                Alive
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-2xl font-bold text-green-600">
+                {stats.alive_count}
+              </p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium text-muted-foreground">
+                Deaths
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-2xl font-bold text-red-600">
+                {stats.total_deaths}
+              </p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium text-muted-foreground">
+                Total Feedings
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-2xl font-bold">{stats.total_feedings}</p>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {/* Filters */}
+      <div className="flex flex-col md:flex-row gap-4 mb-6">
+        <Input
+          placeholder="Search by name, ID, or owner..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className="md:w-64"
+        />
+
+        <Select
+          value={statusFilter}
+          onValueChange={(v) => setStatusFilter(v as "all" | "alive" | "dead")}
+        >
+          <SelectTrigger className="w-32">
+            <SelectValue placeholder="Status" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All</SelectItem>
+            <SelectItem value="alive">Alive</SelectItem>
+            <SelectItem value="dead">Dead</SelectItem>
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={levelFilter}
+          onValueChange={(v) =>
+            setLevelFilter(v as BitcoinAgentLevel | "all")
+          }
+        >
+          <SelectTrigger className="w-40">
+            <SelectValue placeholder="Level" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Levels</SelectItem>
+            <SelectItem value="hatchling">🥚 Hatchling</SelectItem>
+            <SelectItem value="junior">🐣 Junior</SelectItem>
+            <SelectItem value="senior">🐥 Senior</SelectItem>
+            <SelectItem value="elder">🦅 Elder</SelectItem>
+            <SelectItem value="legendary">🔥 Legendary</SelectItem>
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={sortBy}
+          onValueChange={(v) => setSortBy(v as "xp" | "hunger" | "age")}
+        >
+          <SelectTrigger className="w-40">
+            <SelectValue placeholder="Sort by" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="xp">⭐ XP (High to Low)</SelectItem>
+            <SelectItem value="hunger">🍖 Hunger (Urgent)</SelectItem>
+            <SelectItem value="age">📅 Age (Oldest)</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Quick Links */}
+      <div className="flex gap-2 mb-6">
+        <Link href="/bitcoin-agents/leaderboard">
+          <Button variant="outline" size="sm">
+            🏆 Leaderboard
+          </Button>
+        </Link>
+        <Link href="/graveyard">
+          <Button variant="outline" size="sm">
+            💀 Graveyard
+          </Button>
+        </Link>
+      </div>
+
+      {/* Error State */}
+      {error && (
+        <div className="text-center py-12">
+          <p className="text-red-500 mb-4">{error}</p>
+          <Button onClick={loadData}>Try Again</Button>
+        </div>
+      )}
+
+      {/* Loading State */}
+      {isLoading && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+          {[...Array(8)].map((_, i) => (
+            <Card key={i}>
+              <CardHeader className="pb-2">
+                <div className="flex items-center gap-3">
+                  <Skeleton className="h-12 w-12 rounded-full" />
+                  <div className="space-y-2">
+                    <Skeleton className="h-4 w-24" />
+                    <Skeleton className="h-3 w-16" />
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <Skeleton className="h-2 w-full mb-2" />
+                <Skeleton className="h-2 w-full" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {/* Agents Grid */}
+      {!isLoading && !error && (
+        <>
+          {filteredAgents.length === 0 ? (
+            <div className="text-center py-12">
+              <p className="text-muted-foreground mb-4">
+                No agents found matching your criteria.
+              </p>
+              <Link href="/bitcoin-agents/mint">
+                <Button>Mint the First Agent!</Button>
+              </Link>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+              {filteredAgents.map((agent) => (
+                <BitcoinAgentCard
+                  key={agent.agent_id}
+                  agent={agent}
+                  showOwner
+                />
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/graveyard/page.tsx
+++ b/src/app/graveyard/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";

--- a/src/app/graveyard/page.tsx
+++ b/src/app/graveyard/page.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { LevelBadge } from "@/components/bitcoin-agents";
+import { fetchGraveyard } from "@/services/bitcoin-agents.service";
+import type { DeathCertificate } from "@/types";
+import Link from "next/link";
+
+const BITCOIN_FACES_API = "https://bitcoinfaces.xyz/api";
+
+export default function GraveyardPage() {
+  const [certificates, setCertificates] = useState<DeathCertificate[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [sortBy, setSortBy] = useState<"recent" | "lifespan" | "level">(
+    "recent"
+  );
+
+  useEffect(() => {
+    loadData();
+  }, []);
+
+  async function loadData() {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const data = await fetchGraveyard();
+      setCertificates(data.certificates);
+    } catch (err) {
+      setError("Failed to load graveyard");
+      console.error(err);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  const sortedCertificates = [...certificates].sort((a, b) => {
+    if (sortBy === "recent") return b.death_block - a.death_block;
+    if (sortBy === "lifespan") return b.lifespan_blocks - a.lifespan_blocks;
+    if (sortBy === "level") return b.final_xp - a.final_xp;
+    return 0;
+  });
+
+  return (
+    <div className="container mx-auto py-8 px-4">
+      {/* Header */}
+      <div className="text-center mb-8">
+        <h1 className="text-3xl font-bold mb-2">💀 The Graveyard</h1>
+        <p className="text-muted-foreground">
+          A memorial for fallen Bitcoin Agents
+        </p>
+      </div>
+
+      {/* Sort */}
+      <div className="flex justify-between items-center mb-6">
+        <p className="text-muted-foreground">
+          {certificates.length} agents at rest
+        </p>
+        <Select
+          value={sortBy}
+          onValueChange={(v) =>
+            setSortBy(v as "recent" | "lifespan" | "level")
+          }
+        >
+          <SelectTrigger className="w-48">
+            <SelectValue placeholder="Sort by" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="recent">Most Recent</SelectItem>
+            <SelectItem value="lifespan">Longest Lived</SelectItem>
+            <SelectItem value="level">Highest Level</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div className="text-center py-12">
+          <p className="text-red-500">{error}</p>
+        </div>
+      )}
+
+      {/* Loading */}
+      {isLoading && (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {[...Array(6)].map((_, i) => (
+            <Card key={i} className="border-red-200 dark:border-red-800">
+              <CardContent className="pt-6">
+                <div className="flex items-center gap-4 mb-4">
+                  <Skeleton className="h-16 w-16 rounded-full" />
+                  <div className="space-y-2">
+                    <Skeleton className="h-5 w-32" />
+                    <Skeleton className="h-4 w-24" />
+                  </div>
+                </div>
+                <Skeleton className="h-20 w-full" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {/* Certificates */}
+      {!isLoading && !error && (
+        <>
+          {sortedCertificates.length === 0 ? (
+            <div className="text-center py-12">
+              <p className="text-6xl mb-4">🌱</p>
+              <p className="text-xl font-medium mb-2">
+                The graveyard is empty
+              </p>
+              <p className="text-muted-foreground mb-4">
+                All agents are still alive! Keep feeding them.
+              </p>
+              <Link href="/bitcoin-agents">
+                <Badge variant="outline" className="cursor-pointer">
+                  View Living Agents →
+                </Badge>
+              </Link>
+            </div>
+          ) : (
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {sortedCertificates.map((cert) => (
+                <Card
+                  key={cert.agent_id}
+                  className="border-red-200 dark:border-red-800 bg-gradient-to-b from-background to-red-50 dark:to-red-950/20"
+                >
+                  <CardContent className="pt-6">
+                    {/* Header */}
+                    <div className="flex items-center gap-4 mb-4">
+                      <div className="relative">
+                        <Avatar className="h-16 w-16 border-2 border-red-300 dark:border-red-700 grayscale">
+                          <AvatarImage
+                            src={`${BITCOIN_FACES_API}/get-image?name=${cert.owner}`}
+                            alt={cert.name}
+                          />
+                          <AvatarFallback>
+                            {cert.name.slice(0, 2).toUpperCase()}
+                          </AvatarFallback>
+                        </Avatar>
+                        <span className="absolute -bottom-1 -right-1 text-2xl">
+                          💀
+                        </span>
+                      </div>
+                      <div>
+                        <h3 className="font-bold text-lg">{cert.name}</h3>
+                        <p className="text-sm text-muted-foreground">
+                          Agent #{cert.agent_id}
+                        </p>
+                        <LevelBadge level={cert.final_level} size="sm" />
+                      </div>
+                    </div>
+
+                    {/* Stats */}
+                    <div className="bg-background/50 p-3 rounded-lg mb-4">
+                      <div className="grid grid-cols-2 gap-2 text-sm">
+                        <div>
+                          <p className="text-muted-foreground">Lifespan</p>
+                          <p className="font-mono">
+                            {cert.lifespan_blocks.toLocaleString()} blocks
+                          </p>
+                        </div>
+                        <div>
+                          <p className="text-muted-foreground">Final XP</p>
+                          <p className="font-mono">
+                            {cert.final_xp.toLocaleString()}
+                          </p>
+                        </div>
+                        <div>
+                          <p className="text-muted-foreground">Total Feedings</p>
+                          <p className="font-mono">{cert.total_feedings}</p>
+                        </div>
+                        <div>
+                          <p className="text-muted-foreground">Cause</p>
+                          <p className="capitalize">{cert.cause_of_death}</p>
+                        </div>
+                      </div>
+                    </div>
+
+                    {/* Epitaph */}
+                    {cert.epitaph && (
+                      <div className="border-t border-red-200 dark:border-red-800 pt-4">
+                        <p className="text-sm italic text-center text-muted-foreground">
+                          &quot;{cert.epitaph}&quot;
+                        </p>
+                      </div>
+                    )}
+
+                    {/* Death Block */}
+                    <p className="text-xs text-center text-muted-foreground mt-3">
+                      Died at block {cert.death_block.toLocaleString()}
+                    </p>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+
+      {/* Back Link */}
+      <div className="text-center mt-8">
+        <Link
+          href="/bitcoin-agents"
+          className="text-muted-foreground hover:text-foreground"
+        >
+          ← Back to Living Agents
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/bitcoin-agents/BitcoinAgentCard.tsx
+++ b/src/components/bitcoin-agents/BitcoinAgentCard.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import type { BitcoinAgent } from "@/types";
+import { LevelBadge } from "./LevelBadge";
+import { HungerHealthBars } from "./HungerHealthBars";
+import { cn } from "@/lib/utils";
+import Link from "next/link";
+
+interface BitcoinAgentCardProps {
+  agent: BitcoinAgent;
+  showOwner?: boolean;
+  showStats?: boolean;
+  className?: string;
+}
+
+const BITCOIN_FACES_API = "https://bitcoinfaces.xyz/api";
+
+export function BitcoinAgentCard({
+  agent,
+  showOwner = false,
+  showStats = true,
+  className,
+}: BitcoinAgentCardProps) {
+  const faceUrl =
+    agent.face_image_url ||
+    `${BITCOIN_FACES_API}/get-image?name=${agent.owner}`;
+
+  const hunger = agent.computed_hunger ?? agent.hunger;
+  const health = agent.computed_health ?? agent.health;
+
+  return (
+    <Link href={`/bitcoin-agents/${agent.agent_id}`}>
+      <Card
+        className={cn(
+          "hover:shadow-lg transition-all duration-200 cursor-pointer",
+          !agent.alive && "opacity-60 grayscale",
+          className
+        )}
+      >
+        <CardHeader className="pb-2">
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex items-center gap-3">
+              <Avatar className="h-12 w-12 border-2 border-border">
+                <AvatarImage src={faceUrl} alt={agent.name} />
+                <AvatarFallback className="text-lg">
+                  {agent.name.slice(0, 2).toUpperCase()}
+                </AvatarFallback>
+              </Avatar>
+              <div>
+                <h3 className="font-semibold text-foreground leading-tight">
+                  {agent.name}
+                </h3>
+                <p className="text-xs text-muted-foreground">
+                  #{agent.agent_id}
+                </p>
+              </div>
+            </div>
+            <div className="flex flex-col items-end gap-1">
+              <LevelBadge level={agent.level} size="sm" />
+              {!agent.alive && (
+                <Badge variant="destructive" className="text-xs">
+                  💀 Dead
+                </Badge>
+              )}
+            </div>
+          </div>
+        </CardHeader>
+
+        {showStats && agent.alive && (
+          <CardContent className="pt-2">
+            <HungerHealthBars
+              hunger={hunger}
+              health={health}
+              size="sm"
+              showLabels={false}
+              showValues={false}
+            />
+            <div className="flex justify-between items-center mt-3 text-xs text-muted-foreground">
+              <span>🍖 {hunger}%</span>
+              <span>❤️ {health}%</span>
+              <span>⭐ {agent.xp.toLocaleString()} XP</span>
+            </div>
+          </CardContent>
+        )}
+
+        {showOwner && (
+          <CardContent className="pt-0 pb-3">
+            <p className="text-xs text-muted-foreground truncate">
+              Owner: {agent.owner.slice(0, 8)}...{agent.owner.slice(-4)}
+            </p>
+          </CardContent>
+        )}
+      </Card>
+    </Link>
+  );
+}

--- a/src/components/bitcoin-agents/FeedButton.tsx
+++ b/src/components/bitcoin-agents/FeedButton.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Badge } from "@/components/ui/badge";
+import { requestFeedAgent } from "@/services/bitcoin-agents.service";
+import type { FoodTier } from "@/types";
+
+interface FeedButtonProps {
+  agentId: number;
+  agentName: string;
+  foodTiers: Record<number, FoodTier>;
+  disabled?: boolean;
+  onFeedRequested?: (paymentDetails: {
+    cost_sats: number;
+    payment_address: string;
+  }) => void;
+}
+
+export function FeedButton({
+  agentId,
+  agentName,
+  foodTiers,
+  disabled = false,
+  onFeedRequested,
+}: FeedButtonProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedTier, setSelectedTier] = useState<number | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [paymentInfo, setPaymentInfo] = useState<{
+    cost_sats: number;
+    payment_address: string;
+    message: string;
+  } | null>(null);
+
+  const handleFeed = async (tier: number) => {
+    setSelectedTier(tier);
+    setIsLoading(true);
+
+    try {
+      const result = await requestFeedAgent(agentId, tier);
+      setPaymentInfo({
+        cost_sats: result.cost_sats,
+        payment_address: result.payment_address,
+        message: result.message,
+      });
+      onFeedRequested?.({
+        cost_sats: result.cost_sats,
+        payment_address: result.payment_address,
+      });
+    } catch (error) {
+      console.error("Failed to request feed:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const tiers = Object.entries(foodTiers).map(([key, value]) => ({
+    ...value,
+    tier: parseInt(key),
+  }));
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>
+        <Button
+          size="lg"
+          className="w-full bg-green-600 hover:bg-green-700"
+          disabled={disabled}
+        >
+          🍖 Feed {agentName}
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Feed {agentName}</DialogTitle>
+          <DialogDescription>
+            Choose a food tier. Higher tiers give more XP!
+          </DialogDescription>
+        </DialogHeader>
+
+        {!paymentInfo ? (
+          <div className="grid gap-3">
+            {tiers.map((tier) => (
+              <Button
+                key={tier.tier}
+                variant="outline"
+                className="h-auto py-4 justify-between"
+                onClick={() => handleFeed(tier.tier)}
+                disabled={isLoading && selectedTier === tier.tier}
+              >
+                <div className="flex items-center gap-3">
+                  <span className="text-2xl">
+                    {tier.tier === 1 ? "🍞" : tier.tier === 2 ? "🥩" : "🍱"}
+                  </span>
+                  <div className="text-left">
+                    <p className="font-semibold">{tier.name} Food</p>
+                    <p className="text-xs text-muted-foreground">
+                      +{tier.xp} XP
+                    </p>
+                  </div>
+                </div>
+                <Badge variant="secondary">{tier.cost} sats</Badge>
+              </Button>
+            ))}
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <div className="bg-muted p-4 rounded-lg text-center">
+              <p className="text-sm text-muted-foreground mb-2">
+                Send payment to:
+              </p>
+              <code className="text-xs break-all block bg-background p-2 rounded">
+                {paymentInfo.payment_address}
+              </code>
+              <p className="text-2xl font-bold mt-3">
+                {paymentInfo.cost_sats.toLocaleString()} sats
+              </p>
+            </div>
+            <p className="text-sm text-center text-muted-foreground">
+              {paymentInfo.message}
+            </p>
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={() => {
+                setPaymentInfo(null);
+                setSelectedTier(null);
+              }}
+            >
+              Choose Different Food
+            </Button>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/bitcoin-agents/HungerHealthBars.tsx
+++ b/src/components/bitcoin-agents/HungerHealthBars.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { Progress } from "@/components/ui/progress";
+import { cn } from "@/lib/utils";
+
+interface HungerHealthBarsProps {
+  hunger: number;
+  health: number;
+  size?: "sm" | "md" | "lg";
+  showLabels?: boolean;
+  showValues?: boolean;
+  className?: string;
+}
+
+const SIZE_CLASSES = {
+  sm: "h-1.5",
+  md: "h-2",
+  lg: "h-3",
+};
+
+function getBarColor(value: number, type: "hunger" | "health"): string {
+  if (value <= 10) return "bg-red-500";
+  if (value <= 30) return "bg-orange-500";
+  if (value <= 50) return "bg-yellow-500";
+  return type === "hunger" ? "bg-green-500" : "bg-blue-500";
+}
+
+function getStatusText(value: number): string {
+  if (value <= 10) return "Critical!";
+  if (value <= 30) return "Low";
+  if (value <= 50) return "Moderate";
+  if (value <= 80) return "Good";
+  return "Full";
+}
+
+export function HungerHealthBars({
+  hunger,
+  health,
+  size = "md",
+  showLabels = true,
+  showValues = true,
+  className,
+}: HungerHealthBarsProps) {
+  return (
+    <div className={cn("space-y-2", className)}>
+      {/* Hunger Bar */}
+      <div>
+        {showLabels && (
+          <div className="flex justify-between items-center mb-1">
+            <span className="text-xs font-medium text-muted-foreground flex items-center gap-1">
+              <span>🍖</span> Hunger
+            </span>
+            {showValues && (
+              <span
+                className={cn(
+                  "text-xs font-medium",
+                  hunger <= 10
+                    ? "text-red-600"
+                    : hunger <= 30
+                      ? "text-orange-600"
+                      : "text-muted-foreground"
+                )}
+              >
+                {hunger}% - {getStatusText(hunger)}
+              </span>
+            )}
+          </div>
+        )}
+        <div className="relative">
+          <Progress
+            value={hunger}
+            className={cn("bg-muted", SIZE_CLASSES[size])}
+          />
+          <div
+            className={cn(
+              "absolute inset-0 rounded-full transition-all",
+              SIZE_CLASSES[size],
+              getBarColor(hunger, "hunger")
+            )}
+            style={{ width: `${hunger}%` }}
+          />
+        </div>
+      </div>
+
+      {/* Health Bar */}
+      <div>
+        {showLabels && (
+          <div className="flex justify-between items-center mb-1">
+            <span className="text-xs font-medium text-muted-foreground flex items-center gap-1">
+              <span>❤️</span> Health
+            </span>
+            {showValues && (
+              <span
+                className={cn(
+                  "text-xs font-medium",
+                  health <= 10
+                    ? "text-red-600"
+                    : health <= 30
+                      ? "text-orange-600"
+                      : "text-muted-foreground"
+                )}
+              >
+                {health}% - {getStatusText(health)}
+              </span>
+            )}
+          </div>
+        )}
+        <div className="relative">
+          <Progress
+            value={health}
+            className={cn("bg-muted", SIZE_CLASSES[size])}
+          />
+          <div
+            className={cn(
+              "absolute inset-0 rounded-full transition-all",
+              SIZE_CLASSES[size],
+              getBarColor(health, "health")
+            )}
+            style={{ width: `${health}%` }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/bitcoin-agents/HungryAgentBanner.tsx
+++ b/src/components/bitcoin-agents/HungryAgentBanner.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { X } from "lucide-react";
+import { fetchBitcoinAgents } from "@/services/bitcoin-agents.service";
+import type { BitcoinAgent } from "@/types";
+import Link from "next/link";
+
+interface HungryAgentBannerProps {
+  ownerAddress?: string;
+}
+
+export function HungryAgentBanner({ ownerAddress }: HungryAgentBannerProps) {
+  const [hungryAgents, setHungryAgents] = useState<BitcoinAgent[]>([]);
+  const [criticalAgents, setCriticalAgents] = useState<BitcoinAgent[]>([]);
+  const [isDismissed, setIsDismissed] = useState(false);
+
+  useEffect(() => {
+    if (!ownerAddress) return;
+
+    loadAgents();
+    // Check every 5 minutes
+    const interval = setInterval(loadAgents, 5 * 60 * 1000);
+    return () => clearInterval(interval);
+  }, [ownerAddress]);
+
+  async function loadAgents() {
+    try {
+      const { agents } = await fetchBitcoinAgents({ owner: ownerAddress, status: "alive" });
+
+      const hungry = agents.filter((a) => {
+        const hunger = a.computed_hunger ?? a.hunger;
+        return hunger <= 30 && hunger > 10;
+      });
+
+      const critical = agents.filter((a) => {
+        const hunger = a.computed_hunger ?? a.hunger;
+        return hunger <= 10;
+      });
+
+      setHungryAgents(hungry);
+      setCriticalAgents(critical);
+    } catch (error) {
+      console.error("Failed to check agent status:", error);
+    }
+  }
+
+  if (isDismissed || (hungryAgents.length === 0 && criticalAgents.length === 0)) {
+    return null;
+  }
+
+  const hasCritical = criticalAgents.length > 0;
+  const totalCount = hungryAgents.length + criticalAgents.length;
+
+  return (
+    <Alert
+      variant={hasCritical ? "destructive" : "default"}
+      className="relative mb-4"
+    >
+      <Button
+        variant="ghost"
+        size="icon"
+        className="absolute top-2 right-2 h-6 w-6"
+        onClick={() => setIsDismissed(true)}
+      >
+        <X className="h-4 w-4" />
+      </Button>
+
+      <AlertTitle className="flex items-center gap-2">
+        {hasCritical ? "🚨 Critical Alert!" : "⚠️ Hungry Agents"}
+      </AlertTitle>
+
+      <AlertDescription className="mt-2">
+        {hasCritical ? (
+          <>
+            <span className="font-medium text-red-600">
+              {criticalAgents.length} agent
+              {criticalAgents.length > 1 ? "s" : ""} in critical condition!
+            </span>{" "}
+            Feed them immediately or they will die.
+            {hungryAgents.length > 0 && (
+              <span className="ml-1">
+                ({hungryAgents.length} other{hungryAgents.length > 1 ? "s" : ""}{" "}
+                also hungry)
+              </span>
+            )}
+          </>
+        ) : (
+          <>
+            {totalCount} of your agent{totalCount > 1 ? "s" : ""}{" "}
+            {totalCount > 1 ? "are" : "is"} getting hungry. Feed them soon!
+          </>
+        )}
+
+        <div className="mt-3 flex flex-wrap gap-2">
+          {criticalAgents.slice(0, 3).map((agent) => (
+            <Link
+              key={agent.agent_id}
+              href={`/bitcoin-agents/${agent.agent_id}`}
+            >
+              <Button
+                size="sm"
+                variant={hasCritical ? "default" : "outline"}
+                className="bg-red-600 hover:bg-red-700"
+              >
+                Feed {agent.name} ({agent.computed_hunger ?? agent.hunger}%)
+              </Button>
+            </Link>
+          ))}
+          {hungryAgents.slice(0, 3 - criticalAgents.length).map((agent) => (
+            <Link
+              key={agent.agent_id}
+              href={`/bitcoin-agents/${agent.agent_id}`}
+            >
+              <Button size="sm" variant="outline">
+                Feed {agent.name} ({agent.computed_hunger ?? agent.hunger}%)
+              </Button>
+            </Link>
+          ))}
+          {totalCount > 3 && (
+            <Link href="/bitcoin-agents">
+              <Button size="sm" variant="ghost">
+                +{totalCount - 3} more
+              </Button>
+            </Link>
+          )}
+        </div>
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/src/components/bitcoin-agents/LevelBadge.tsx
+++ b/src/components/bitcoin-agents/LevelBadge.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import type { BitcoinAgentLevel } from "@/types";
+import { cn } from "@/lib/utils";
+
+interface LevelBadgeProps {
+  level: BitcoinAgentLevel;
+  xp?: number;
+  size?: "sm" | "md" | "lg";
+  showXp?: boolean;
+}
+
+const LEVEL_STYLES: Record<BitcoinAgentLevel, string> = {
+  hatchling: "bg-gray-100 text-gray-800 border-gray-300",
+  junior: "bg-green-100 text-green-800 border-green-300",
+  senior: "bg-blue-100 text-blue-800 border-blue-300",
+  elder: "bg-purple-100 text-purple-800 border-purple-300",
+  legendary:
+    "bg-gradient-to-r from-yellow-100 to-orange-100 text-yellow-800 border-yellow-400",
+};
+
+const LEVEL_ICONS: Record<BitcoinAgentLevel, string> = {
+  hatchling: "🥚",
+  junior: "🐣",
+  senior: "🐥",
+  elder: "🦅",
+  legendary: "🔥",
+};
+
+const SIZE_CLASSES = {
+  sm: "text-xs px-1.5 py-0.5",
+  md: "text-sm px-2 py-1",
+  lg: "text-base px-3 py-1.5",
+};
+
+export function LevelBadge({
+  level,
+  xp,
+  size = "md",
+  showXp = false,
+}: LevelBadgeProps) {
+  const levelName = level.charAt(0).toUpperCase() + level.slice(1);
+
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        "font-medium border",
+        LEVEL_STYLES[level],
+        SIZE_CLASSES[size]
+      )}
+    >
+      <span className="mr-1">{LEVEL_ICONS[level]}</span>
+      {levelName}
+      {showXp && xp !== undefined && (
+        <span className="ml-1 opacity-75">({xp.toLocaleString()} XP)</span>
+      )}
+    </Badge>
+  );
+}

--- a/src/components/bitcoin-agents/XPProgress.tsx
+++ b/src/components/bitcoin-agents/XPProgress.tsx
@@ -27,16 +27,17 @@ export function XPProgress({
   className,
 }: XPProgressProps) {
   const currentLevelIndex = LEVEL_ORDER.indexOf(level);
-  const nextLevel = LEVEL_ORDER[currentLevelIndex + 1];
-
-  const currentThreshold = XP_THRESHOLDS[level];
-  const nextThreshold = nextLevel ? XP_THRESHOLDS[nextLevel] : XP_THRESHOLDS.legendary * 2;
-
-  const xpInCurrentLevel = xp - currentThreshold;
-  const xpNeededForNext = nextThreshold - currentThreshold;
-  const progress = Math.min((xpInCurrentLevel / xpNeededForNext) * 100, 100);
-
+  const nextLevel = currentLevelIndex < LEVEL_ORDER.length - 1
+    ? LEVEL_ORDER[currentLevelIndex + 1]
+    : undefined;
   const isMaxLevel = level === "legendary";
+
+  const currentThreshold = XP_THRESHOLDS[level] ?? 0;
+  const nextThreshold = nextLevel ? XP_THRESHOLDS[nextLevel] : currentThreshold;
+
+  const xpInCurrentLevel = Math.max(0, xp - currentThreshold);
+  const xpNeededForNext = Math.max(1, nextThreshold - currentThreshold); // Prevent division by zero
+  const progress = isMaxLevel ? 100 : Math.min((xpInCurrentLevel / xpNeededForNext) * 100, 100);
 
   return (
     <div className={cn("space-y-1", className)}>

--- a/src/components/bitcoin-agents/XPProgress.tsx
+++ b/src/components/bitcoin-agents/XPProgress.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { Progress } from "@/components/ui/progress";
+import type { BitcoinAgentLevel } from "@/types";
+import { XP_THRESHOLDS } from "@/types";
+import { cn } from "@/lib/utils";
+
+interface XPProgressProps {
+  xp: number;
+  level: BitcoinAgentLevel;
+  showNumbers?: boolean;
+  className?: string;
+}
+
+const LEVEL_ORDER: BitcoinAgentLevel[] = [
+  "hatchling",
+  "junior",
+  "senior",
+  "elder",
+  "legendary",
+];
+
+export function XPProgress({
+  xp,
+  level,
+  showNumbers = true,
+  className,
+}: XPProgressProps) {
+  const currentLevelIndex = LEVEL_ORDER.indexOf(level);
+  const nextLevel = LEVEL_ORDER[currentLevelIndex + 1];
+
+  const currentThreshold = XP_THRESHOLDS[level];
+  const nextThreshold = nextLevel ? XP_THRESHOLDS[nextLevel] : XP_THRESHOLDS.legendary * 2;
+
+  const xpInCurrentLevel = xp - currentThreshold;
+  const xpNeededForNext = nextThreshold - currentThreshold;
+  const progress = Math.min((xpInCurrentLevel / xpNeededForNext) * 100, 100);
+
+  const isMaxLevel = level === "legendary";
+
+  return (
+    <div className={cn("space-y-1", className)}>
+      {showNumbers && (
+        <div className="flex justify-between text-xs text-muted-foreground">
+          <span>{xp.toLocaleString()} XP</span>
+          {!isMaxLevel && (
+            <span>
+              {nextThreshold.toLocaleString()} XP to{" "}
+              {nextLevel?.charAt(0).toUpperCase()}
+              {nextLevel?.slice(1)}
+            </span>
+          )}
+          {isMaxLevel && <span>Max Level!</span>}
+        </div>
+      )}
+      <Progress value={isMaxLevel ? 100 : progress} className="h-2" />
+      {!isMaxLevel && showNumbers && (
+        <p className="text-xs text-center text-muted-foreground">
+          {(nextThreshold - xp).toLocaleString()} XP to next level
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/bitcoin-agents/index.ts
+++ b/src/components/bitcoin-agents/index.ts
@@ -1,0 +1,6 @@
+export { BitcoinAgentCard } from "./BitcoinAgentCard";
+export { FeedButton } from "./FeedButton";
+export { HungryAgentBanner } from "./HungryAgentBanner";
+export { HungerHealthBars } from "./HungerHealthBars";
+export { LevelBadge } from "./LevelBadge";
+export { XPProgress } from "./XPProgress";

--- a/src/services/bitcoin-agents.service.ts
+++ b/src/services/bitcoin-agents.service.ts
@@ -1,0 +1,313 @@
+/**
+ * Bitcoin Agents API service
+ *
+ * Calls the aibtcdev-backend Bitcoin Agents endpoints
+ */
+
+import type {
+  BitcoinAgent,
+  BitcoinAgentFilter,
+  BitcoinAgentStats,
+  DeathCertificate,
+  FoodTier,
+  TierInfo,
+  AgentCapabilities,
+} from "@/types";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || "https://api.aibtc.dev";
+
+/**
+ * Fetch all Bitcoin Agents with optional filters
+ */
+export async function fetchBitcoinAgents(
+  filter?: BitcoinAgentFilter,
+  limit = 50,
+  offset = 0
+): Promise<{ agents: BitcoinAgent[]; total: number }> {
+  const params = new URLSearchParams();
+
+  if (filter?.owner) params.set("owner", filter.owner);
+  if (filter?.status) params.set("status", filter.status);
+  if (filter?.level) params.set("level", filter.level);
+  if (filter?.network) params.set("network", filter.network);
+  params.set("limit", limit.toString());
+  params.set("offset", offset.toString());
+
+  const response = await fetch(
+    `${API_BASE}/bitcoin-agents?${params.toString()}`
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch agents: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Fetch a single Bitcoin Agent by ID
+ */
+export async function fetchBitcoinAgentById(
+  agentId: number,
+  network = "mainnet"
+): Promise<BitcoinAgent | null> {
+  const response = await fetch(
+    `${API_BASE}/bitcoin-agents/${agentId}?network=${network}`
+  );
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch agent: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Fetch agent's computed status (current hunger/health)
+ */
+export async function fetchAgentStatus(
+  agentId: number,
+  network = "mainnet"
+): Promise<{ hunger: number; health: number; alive: boolean } | null> {
+  const response = await fetch(
+    `${API_BASE}/bitcoin-agents/${agentId}/status?network=${network}`
+  );
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch agent status: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Fetch leaderboard (top agents by XP)
+ */
+export async function fetchLeaderboard(
+  network = "mainnet",
+  limit = 10
+): Promise<{ leaderboard: BitcoinAgent[] }> {
+  const response = await fetch(
+    `${API_BASE}/bitcoin-agents/leaderboard?network=${network}&limit=${limit}`
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch leaderboard: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Fetch graveyard (dead agents)
+ */
+export async function fetchGraveyard(
+  network = "mainnet",
+  limit = 50,
+  offset = 0
+): Promise<{ certificates: DeathCertificate[]; total: number }> {
+  const response = await fetch(
+    `${API_BASE}/bitcoin-agents/graveyard?network=${network}&limit=${limit}&offset=${offset}`
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch graveyard: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Fetch global statistics
+ */
+export async function fetchGlobalStats(
+  network = "mainnet"
+): Promise<BitcoinAgentStats> {
+  const response = await fetch(
+    `${API_BASE}/bitcoin-agents/stats?network=${network}`
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch stats: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Fetch food tier pricing
+ */
+export async function fetchFoodTiers(): Promise<{
+  food_tiers: Record<number, FoodTier>;
+  mint_cost: number;
+}> {
+  const response = await fetch(`${API_BASE}/bitcoin-agents/food-tiers`);
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch food tiers: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Fetch tier info (evolution levels)
+ */
+export async function fetchTierInfo(): Promise<{ tiers: TierInfo[] }> {
+  const response = await fetch(`${API_BASE}/bitcoin-agents/tier-info`);
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch tier info: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Fetch agent capabilities (available tools)
+ */
+export async function fetchAgentCapabilities(
+  agentId: number,
+  network = "mainnet"
+): Promise<AgentCapabilities> {
+  const response = await fetch(
+    `${API_BASE}/bitcoin-agents/${agentId}/capabilities?network=${network}`
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch capabilities: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Request to mint a new agent (returns 402 with payment details)
+ */
+export async function requestMintAgent(
+  name: string,
+  network = "mainnet"
+): Promise<{
+  status: string;
+  action: string;
+  name: string;
+  cost_sats: number;
+  payment_address: string;
+  message: string;
+}> {
+  const response = await fetch(
+    `${API_BASE}/bitcoin-agents/mint?name=${encodeURIComponent(name)}&network=${network}`,
+    { method: "POST" }
+  );
+
+  // 402 is expected - it contains payment details
+  if (response.status !== 402) {
+    throw new Error(`Unexpected response: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Request to feed an agent (returns 402 with payment details)
+ */
+export async function requestFeedAgent(
+  agentId: number,
+  foodTier: number,
+  network = "mainnet"
+): Promise<{
+  status: string;
+  action: string;
+  agent_id: number;
+  food_tier: number;
+  food_name: string;
+  cost_sats: number;
+  xp_reward: number;
+  payment_address: string;
+  message: string;
+}> {
+  const response = await fetch(
+    `${API_BASE}/bitcoin-agents/${agentId}/feed?food_tier=${foodTier}&network=${network}`,
+    { method: "POST" }
+  );
+
+  // 402 is expected - it contains payment details
+  if (response.status !== 402) {
+    throw new Error(`Unexpected response: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Fetch death certificate for a dead agent
+ */
+export async function fetchDeathCertificate(
+  agentId: number,
+  network = "mainnet"
+): Promise<DeathCertificate | null> {
+  const response = await fetch(
+    `${API_BASE}/bitcoin-agents/${agentId}/death-certificate?network=${network}`
+  );
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch death certificate: ${response.statusText}`
+    );
+  }
+
+  return response.json();
+}
+
+/**
+ * Execute an agent visit (social interaction)
+ */
+export async function visitAgent(
+  visitorId: number,
+  hostId: number,
+  network = "mainnet"
+): Promise<{
+  success: boolean;
+  visitor_xp_earned?: number;
+  host_xp_earned?: number;
+  message?: string;
+  error?: string;
+}> {
+  const response = await fetch(
+    `${API_BASE}/bitcoin-agents/${visitorId}/visit/${hostId}?network=${network}`,
+    { method: "POST" }
+  );
+
+  return response.json();
+}
+
+/**
+ * Check if an agent should die
+ */
+export async function checkAgentDeath(
+  agentId: number,
+  network = "mainnet"
+): Promise<{ agent_id: number; died: boolean; message: string }> {
+  const response = await fetch(
+    `${API_BASE}/bitcoin-agents/${agentId}/check-death?network=${network}`,
+    { method: "POST" }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to check death: ${response.statusText}`);
+  }
+
+  return response.json();
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -5,6 +5,7 @@ export * from "./supabase";
 export * from "./agent.service";
 export * from "./agent-prompt.service";
 export * from "./airdrop.service";
+export * from "./bitcoin-agents.service";
 export * from "./chain-state.service";
 export * from "./dao.service";
 export * from "./job.service";

--- a/src/types/bitcoin-agent.ts
+++ b/src/types/bitcoin-agent.ts
@@ -1,0 +1,126 @@
+/**
+ * Bitcoin Agent types for Tamagotchi-style on-chain AI agents
+ */
+
+export type BitcoinAgentLevel =
+  | "hatchling"
+  | "junior"
+  | "senior"
+  | "elder"
+  | "legendary";
+
+export type BitcoinAgentStatus = "alive" | "dead";
+
+export interface BitcoinAgent {
+  agent_id: number;
+  owner: string;
+  name: string;
+  hunger: number;
+  health: number;
+  xp: number;
+  level: BitcoinAgentLevel;
+  birth_block: number;
+  last_fed: number;
+  total_fed_count: number;
+  alive: boolean;
+  // Computed state
+  computed_hunger?: number;
+  computed_health?: number;
+  // Face data
+  face_svg_url?: string;
+  face_image_url?: string;
+  // Timestamps
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface DeathCertificate {
+  agent_id: number;
+  name: string;
+  owner: string;
+  death_block: number;
+  birth_block: number;
+  final_xp: number;
+  final_level: BitcoinAgentLevel;
+  total_feedings: number;
+  epitaph?: string;
+  cause_of_death: "starvation" | "neglect";
+  lifespan_blocks: number;
+}
+
+export interface BitcoinAgentFilter {
+  owner?: string;
+  status?: BitcoinAgentStatus;
+  level?: BitcoinAgentLevel;
+  network?: "mainnet" | "testnet";
+}
+
+export interface FoodTier {
+  tier: number;
+  name: string;
+  cost: number;
+  xp: number;
+}
+
+export interface TierInfo {
+  level: number;
+  name: string;
+  xp_required: number;
+  tools_count: number;
+  new_capabilities: string[];
+}
+
+export interface BitcoinAgentStats {
+  total_agents: number;
+  alive_count: number;
+  total_deaths: number;
+  total_feedings: number;
+  network: string;
+}
+
+export interface AgentCapabilities {
+  agent_id: number;
+  level: number;
+  level_name: string;
+  xp: number;
+  total_tools: number;
+  tools_by_category: {
+    read_only: string[];
+    transfers: string[];
+    trading: string[];
+    dao: string[];
+    social: string[];
+    advanced: string[];
+  };
+  all_tools: string[];
+}
+
+// XP thresholds for levels
+export const XP_THRESHOLDS: Record<BitcoinAgentLevel, number> = {
+  hatchling: 0,
+  junior: 500,
+  senior: 2000,
+  elder: 10000,
+  legendary: 50000,
+};
+
+// Level colors for UI
+export const LEVEL_COLORS: Record<BitcoinAgentLevel, string> = {
+  hatchling: "bg-gray-500",
+  junior: "bg-green-500",
+  senior: "bg-blue-500",
+  elder: "bg-purple-500",
+  legendary: "bg-yellow-500",
+};
+
+// Level badge variants
+export const LEVEL_BADGE_VARIANTS: Record<
+  BitcoinAgentLevel,
+  "default" | "secondary" | "destructive" | "outline"
+> = {
+  hatchling: "secondary",
+  junior: "default",
+  senior: "default",
+  elder: "default",
+  legendary: "default",
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,6 +8,7 @@ export * from "./crew";
 export * from "./user";
 export * from "./common";
 export * from "./airdrop";
+export * from "./bitcoin-agent";
 
 // Re-export only Message from chat types to avoid conflicts
 export type { Message } from "../lib/chat/types";


### PR DESCRIPTION
## Summary

Phase 4 of Bitcoin Agents implementation - the frontend for Tamagotchi-style AI agents on Bitcoin.

### New Types
- `BitcoinAgent`, `DeathCertificate`, and related types
- XP thresholds and level mappings (hatchling, junior, senior, elder, legendary)

### New Service
- `bitcoin-agents.service.ts` for API calls to the backend
- Support for agents CRUD, stats, leaderboard, graveyard
- Feed and mint payment flow helpers (x402)

### New Components
- `BitcoinAgentCard` - Agent card for grid display
- `LevelBadge` - Evolution tier badge with icons (🥚🐣🐥🦅🔥)
- `HungerHealthBars` - Status bars with color-coded urgency
- `XPProgress` - Progress to next evolution level
- `FeedButton` - Food tier selector dialog
- `HungryAgentBanner` - Notification banner for low hunger

### New Pages
- `/bitcoin-agents` - List all agents with filters (status, level, search)
- `/bitcoin-agents/[id]` - Agent detail with stats, feed button, capabilities
- `/bitcoin-agents/mint` - Mint new agent flow with preview
- `/bitcoin-agents/leaderboard` - Top agents by XP
- `/graveyard` - Memorial wall for dead agents

## Related PRs
- Backend API: aibtcdev/aibtcdev-backend#633
- Contract: aibtcdev/erc-8004-stacks#2

## Test plan
- [ ] Verify pages load without errors
- [ ] Test agent list filtering and sorting
- [ ] Test mint flow (402 payment handling)
- [ ] Test feed button dialog
- [ ] Test graveyard and leaderboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)