### PR TITLE
chore: add archive banners to README and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+> **This repository has been archived.** Development has moved to [landing-page](https://github.com/aibtcdev/landing-page).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> **This repository has been archived.** Development has moved to [landing-page](https://github.com/aibtcdev/landing-page).
+
 # AIBTC Frontend
 
 ## Prerequisites


### PR DESCRIPTION
This repository has been superseded by [landing-page](https://github.com/aibtcdev/landing-page).

## Changes
- Prepend archive notice banner to `README.md`
- Create `CLAUDE.md` with archive notice banner

This repo will be archived soon.